### PR TITLE
WHIP:Support send sctp

### DIFF
--- a/libavformat/rtcenc.c
+++ b/libavformat/rtcenc.c
@@ -189,6 +189,7 @@ typedef struct RTCContext {
     /* The SRTP send context, to encrypt outgoing packets. */
     struct SRTPContext srtp_audio_send;
     struct SRTPContext srtp_video_send;
+    struct SRTPContext srtp_rtcp_send;
     /* The SRTP receive context, to decrypt incoming packets. */
     struct SRTPContext srtp_recv;
 
@@ -1319,6 +1320,12 @@ static int setup_srtp(AVFormatContext *s)
         goto end;
     }
 
+    ret = ff_srtp_set_crypto(&rtc->srtp_rtcp_send, suite, buf);
+    if (ret < 0) {
+        av_log(s, AV_LOG_ERROR, "Failed to set crypto for rtcp send\n");
+        goto end;
+    }
+
     /* Setup SRTP context for incoming packets */
     if (!av_base64_encode(buf, sizeof(buf), recv_key, sizeof(recv_key))) {
         av_log(s, AV_LOG_ERROR, "Failed to encode recv key\n");
@@ -1405,7 +1412,6 @@ static int create_rtp_muxer(AVFormatContext *s)
         av_dict_set(&opts, "payload_type", buf, 0);
         snprintf(buf, sizeof(buf), "%d", is_video? rtc->video_ssrc : rtc->audio_ssrc);
         av_dict_set(&opts, "ssrc", buf, 0);
-        av_dict_set(&opts, "rtpflags", "4", 0); /* FF_RTP_FLAG_SKIP_RTCP */
 
         ret = avformat_write_header(rtp_ctx, &opts);
         if (ret < 0) {
@@ -1446,14 +1452,10 @@ static int on_rtp_write_packet(void *opaque, uint8_t *buf, int buf_size)
     if (buf_size < 12 || (buf[0] & 0xC0) != 0x80)
         return 0;
 
-    /* RTCP is not supported yet. */
+    /* Only support audio, video and rtcp. */
     is_rtcp = buf[1] >= 192 && buf[1] <= 223;
-    if (is_rtcp)
-        return 0;
-
-    /* Only support audio and video. */
     payload_type = buf[1] & 0x7f;
-    if (payload_type != rtc->video_payload_type && payload_type != rtc->audio_payload_type) {
+    if (!is_rtcp && payload_type != rtc->video_payload_type && payload_type != rtc->audio_payload_type) {
         return 0;
     }
 
@@ -1478,7 +1480,8 @@ static int on_rtp_write_packet(void *opaque, uint8_t *buf, int buf_size)
     }
 
     /* Encrypt by SRTP and send out. */
-    srtp = payload_type == rtc->video_payload_type ? &rtc->srtp_video_send : &rtc->srtp_audio_send;
+    srtp = is_rtcp ? &rtc->srtp_rtcp_send
+                   : payload_type == rtc->video_payload_type ? &rtc->srtp_video_send : &rtc->srtp_audio_send;
     cipher_size = ff_srtp_encrypt(srtp, buf, buf_size, cipher, sizeof(cipher));
     if (cipher_size <= 0 || cipher_size < buf_size) {
         av_log(s, AV_LOG_WARNING, "Failed to encrypt packet=%dB, cipher=%dB\n", buf_size, cipher_size);
@@ -1727,6 +1730,7 @@ static av_cold void rtc_deinit(AVFormatContext *s)
     ffurl_closep(&rtc->udp_uc);
     ff_srtp_free(&rtc->srtp_audio_send);
     ff_srtp_free(&rtc->srtp_video_send);
+    ff_srtp_free(&rtc->srtp_rtcp_send);
     ff_srtp_free(&rtc->srtp_recv);
 }
 


### PR DESCRIPTION
用于支持SRS的rtc2rtmp功能。因为此功能需要`sender report`里面的ntp time用于音视频同步，如果不发送SR，将无法实现rtc2rtmp的功能。

相关代码在`srs_app_rtc_source.cpp`文件里面
```
srs_error_t SrsRtcFrameBuilder::on_rtp(SrsRtpPacket *pkt)
{
    srs_error_t err = srs_success;

    if (!pkt->payload()) {
        return err;
    }

    // Have no received any sender report, can't calculate avsync_time,
    // discard it to avoid timestamp problem in live source
    if (pkt->get_avsync_time() <= 0) {
        return err;
    }

    if (pkt->is_audio()) {
        err = transcode_audio(pkt);
    } else {
        err = packet_video(pkt);
    }

    return err;
}
```

**测试**
开启rtc2rtmp功能：
```
vhost __defaultVhost__ {
    rtc {
        enabled     on;
        rtc_to_rtmp on;
    }
}
```
用https://github.com/ossrs/ffmpeg-webrtc/pull/1#issue-1669957414 方法进行推流测试。
能够通过rtmp协议播放，即为成功。


