### PR TITLE
 WHIP:Support for baseline/main/high profile encoding without B frames

### DIFF
--- a/libavformat/rtcenc.c
+++ b/libavformat/rtcenc.c
@@ -962,9 +962,9 @@ static int parse_codec(AVFormatContext *s)
                        desc ? desc->name : "unknown");
                 return AVERROR_PATCHWELCOME;
             }
-            if (par->profile > 0 && (par->profile & ~FF_PROFILE_H264_CONSTRAINED) != FF_PROFILE_H264_BASELINE) {
-                av_log(s, AV_LOG_ERROR, "Profile %d of stream %d is not baseline, currently unsupported by RTC\n",
-                       par->profile, i);
+
+            if (par->video_delay > 0) {
+                av_log(s, AV_LOG_ERROR, "Unsupported B frames by RTC\n");
                 return AVERROR_PATCHWELCOME;
             }
 


### PR DESCRIPTION
ffmpeg推流时，需要增加`-bf 0` 以禁用B帧。
```
ffmpeg -re -i ~/git/srs/trunk/doc/source.flv \
    -vcodec libx264 -profile:v high -r 25 -g 50 -bf 0 -acodec libopus -ar 48000 -ac 2 \
    -f rtc 'http://localhost:7080/whip/endpoint/abc123'
```