### PR TITLE
Optimize DTLS Handshake and ICE Handling for Improved Performance

### DIFF
--- a/doc/muxers.texi
+++ b/doc/muxers.texi
@@ -1361,21 +1361,9 @@ This muxer supports the following options:
 
 @table @option
 
-@item ice_arq_max @var{integer}
-Set the maximum number of retransmissions for the ICE ARQ mechanism.
-Default value is 5.
-
-@item ice_arq_timeout @var{integer}
-Set the start timeout in milliseconds for the ICE ARQ mechanism.
-Default value is 30.
-
-@item dtls_arq_max @var{integer}
-Set the maximum number of retransmissions for the DTLS ARQ mechanism.
-Default value is 5.
-
-@item dtls_arq_timeout @var{integer}
-Set the start timeout in milliseconds for the DTLS ARQ mechanism.
-Default value is 50.
+@item handshake_timeout @var{integer}
+Set the timeout in milliseconds for ICE and DTLS handshake.
+Default value is 5000.
 
 @item pkt_size @var{integer}
 Set the maximum size, in bytes, of RTP packets that send out.

--- a/libavformat/rtcenc.c
+++ b/libavformat/rtcenc.c
@@ -72,19 +72,7 @@
  * but please keep in mind that the `pkt_size` option limits the packet size to 1400.
  */
 #define MAX_UDP_BUFFER_SIZE 4096
-/*
- * Supported DTLS cipher suites for FFmpeg as a DTLS client.
- * These cipher suites are used to negotiate with DTLS servers.
- *
- * It is advisable to use a limited number of cipher suites to reduce
- * the size of DTLS UDP packets.
- */
-#define DTLS_CIPHER_SUTES "ECDHE-ECDSA-AES128-GCM-SHA256"\
-    ":ECDHE-RSA-AES128-GCM-SHA256"\
-    ":ECDHE-ECDSA-AES128-SHA"\
-    ":ECDHE-RSA-AES128-SHA"\
-    ":ECDHE-ECDSA-AES256-SHA"\
-    ":ECDHE-RSA-AES256-SHA"
+
 /**
  * The size of the Secure Real-time Transport Protocol (SRTP) master key material
  * that is exported by Secure Sockets Layer (SSL) after a successful Datagram
@@ -410,8 +398,14 @@ static av_cold int openssl_dtls_init_context(DTLSContext *ctx)
     }
 #endif
 
-    /* We use "ALL", while you can use "DEFAULT" means "ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2" */
-    if (SSL_CTX_set_cipher_list(dtls_ctx, DTLS_CIPHER_SUTES) != 1) {
+    /**
+     * We use "ALL", while you can use "DEFAULT" means "ALL:!EXPORT:!LOW:!aNULL:!eNULL:!SSLv2"
+     *      Cipher Suite: ECDHE-ECDSA-AES128-CBC-SHA (0xc009)
+     *      Cipher Suite: ECDHE-RSA-AES128-CBC-SHA (0xc013)
+     *      Cipher Suite: ECDHE-ECDSA-AES256-CBC-SHA (0xc00a)
+     *      Cipher Suite: ECDHE-RSA-AES256-CBC-SHA (0xc014)
+     */
+    if (SSL_CTX_set_cipher_list(dtls_ctx, "ALL") != 1) {
         av_log(s1, AV_LOG_ERROR, "DTLS: SSL_CTX_set_cipher_list failed\n");
         return AVERROR(EINVAL);
     }

--- a/libavformat/rtcenc.c
+++ b/libavformat/rtcenc.c
@@ -460,7 +460,9 @@ static av_cold int openssl_dtls_init_context(DTLSContext *ctx)
      */
     SSL_set_options(dtls, SSL_OP_NO_QUERY_MTU);
     SSL_set_mtu(dtls, ctx->pkt_size);
+#if OPENSSL_VERSION_NUMBER >= 0x100010b0L /* OpenSSL 1.0.1k */
     DTLS_set_link_mtu(dtls, ctx->pkt_size);
+#endif
 
     bio_in = ctx->bio_in = BIO_new(BIO_s_mem());
     if (!bio_in) {
@@ -637,10 +639,10 @@ static long openssl_dtls_bio_out_callback_ex(BIO *b, int oper, const char *argp,
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L // v3.0.x
     req_size = len;
-    av_log(s1, AV_LOG_DEBUG, "bio callback b=%p, oper=%d, argp=%p, len=%ld, argi=%d, argl=%ld, retvalue=%d, processed=%p, req_size=%d\n",
+    av_log(s1, AV_LOG_DEBUG, "DTLS: bio callback b=%p, oper=%d, argp=%p, len=%ld, argi=%d, argl=%ld, retvalue=%d, processed=%p, req_size=%d\n",
         b, oper, argp, len, argi, argl, retvalue, processed, req_size);
 #else
-    av_log(s1, AV_LOG_DEBUG, "bio callback b=%p, oper=%d, argp=%p, argi=%d, argl=%ld, retvalue=%ld, req_size=%d\n",
+    av_log(s1, AV_LOG_DEBUG, "DTLS: bio callback b=%p, oper=%d, argp=%p, argi=%d, argl=%ld, retvalue=%ld, req_size=%d\n",
         b, oper, argp, argi, argl, retvalue, req_size);
 #endif
 


### PR DESCRIPTION
1. Merge ICE and DTLS ARQ max retry options into a single handshake timeout.
1. Utilize DTLS server role to prevent ARQ, as the peer DTLS client will handle ARQ.
1. Replace IO from DTLSContext with a callback function.
1. Measure and analyze the time cost for each step in the process.
1. Implement DTLS BIO callback for packet fragmentation using BIO_set_callback.
1. Generate private key and certificate prior to ICE for faster handshake.
1. Refine DTLS MTU settings using SSL_set_mtu and DTLS_set_link_mtu.
1. Provide callback for DTLS state, returning errors when DTLS encounters issues or closes.
1. Consolidate ICE request/response handling and DTLS handshake into a single function.